### PR TITLE
allow depfiles to not have a newline after the final line

### DIFF
--- a/src/depfile.rs
+++ b/src/depfile.rs
@@ -63,7 +63,7 @@ pub fn parse<'a>(scanner: &mut Scanner<'a>) -> ParseResult<Deps<'a>> {
             Some(p) => deps.push(p),
         }
     }
-    scanner.expect('\n')?;
+    scanner.skip('\n');
     scanner.expect('\0')?;
 
     Ok(Deps { target, deps })
@@ -90,5 +90,12 @@ mod tests {
         println!("{:?}", deps);
         assert_eq!(deps.target, "build/browse.o");
         assert_eq!(deps.deps.len(), 3);
+    }
+
+    #[test]
+    fn test_parse_without_final_newline() {
+        let deps = must_parse("build/browse.o: src/browse.cc\0");
+        assert_eq!(deps.target, "build/browse.o");
+        assert_eq!(deps.deps.len(), 1);
     }
 }

--- a/src/depfile.rs
+++ b/src/depfile.rs
@@ -72,17 +72,21 @@ pub fn parse<'a>(scanner: &mut Scanner<'a>) -> ParseResult<Deps<'a>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[test]
-    fn test_parse() {
-        let mut scanner =
-            Scanner::new("build/browse.o: src/browse.cc src/browse.h build/browse_py.h\n\0");
-        let deps = match parse(&mut scanner) {
+
+    fn must_parse<'a>(s: &'a str) -> Deps<'a> {
+        let mut scanner = Scanner::new(s);
+        match parse(&mut scanner) {
             Err(err) => {
                 println!("{}", scanner.format_parse_error("test", err));
                 panic!("failed parse");
             }
             Ok(d) => d,
-        };
+        }
+    }
+
+    #[test]
+    fn test_parse() {
+        let deps = must_parse("build/browse.o: src/browse.cc src/browse.h build/browse_py.h\n\0");
         println!("{:?}", deps);
         assert_eq!(deps.target, "build/browse.o");
         assert_eq!(deps.deps.len(), 3);

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -51,11 +51,16 @@ impl<'a> Scanner<'a> {
         self.next();
         c
     }
+    pub fn skip(&mut self, ch: char) -> bool {
+        if self.peek() == ch {
+            self.next();
+            return true;
+        }
+        false
+    }
 
     pub fn skip_spaces(&mut self) {
-        while self.peek() == ' ' {
-            self.next();
-        }
+        while self.skip(' ') {}
     }
 
     pub fn expect(&mut self, ch: char) -> ParseResult<()> {


### PR DESCRIPTION
The build.ninja.d written by gn for the llvm/gn build dir
on my linux box just ends without a newline after its (only) line.