### PR TITLE
Make "default" handling more ninja-compatible

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -11,14 +11,14 @@ pub trait Env {
 }
 
 /// One token within an EvalString, either literal text or a variable reference.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum EvalPart<T: AsRef<str>> {
     Literal(T),
     VarRef(T),
 }
 
 /// A parsed but unexpanded variable-reference string, e.g. "cc $in -o $out".
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct EvalString<T: AsRef<str>>(Vec<EvalPart<T>>);
 impl<T: AsRef<str>> EvalString<T> {
     pub fn new(parts: Vec<EvalPart<T>>) -> Self {
@@ -81,7 +81,7 @@ impl<'a> Env for Vars<'a> {
 /// For variables attached to a rule we keep them unexpanded in memory because
 /// they may be expanded in multiple different ways depending on which rule uses
 /// them.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct LazyVars(Vec<(String, EvalString<String>)>);
 #[allow(clippy::new_without_default)]
 impl LazyVars {

--- a/src/load.rs
+++ b/src/load.rs
@@ -142,7 +142,14 @@ impl Loader {
                 Statement::Include(f) => trace::scope("include", || self.read_file(&f))?,
                 // TODO: implement scoping for subninja
                 Statement::Subninja(f) => trace::scope("subninja", || self.read_file(&f))?,
-                Statement::Default(f) => self.default.push(self.graph.file_id(f.target)),
+                Statement::Default(d) => {
+                    let mut v: Vec<graph::FileId> = d
+                        .targets
+                        .into_iter()
+                        .map(|f| self.graph.file_id(f))
+                        .collect();
+                    self.default.append(&mut v)
+                }
                 Statement::Rule(r) => {
                     self.rules.insert(r.name.clone(), r);
                 }

--- a/src/load.rs
+++ b/src/load.rs
@@ -142,7 +142,7 @@ impl Loader {
                 Statement::Include(f) => trace::scope("include", || self.read_file(&f))?,
                 // TODO: implement scoping for subninja
                 Statement::Subninja(f) => trace::scope("subninja", || self.read_file(&f))?,
-                Statement::Default(f) => self.default.push(self.graph.file_id(f)),
+                Statement::Default(f) => self.default.push(self.graph.file_id(f.target)),
                 Statement::Rule(r) => {
                     self.rules.insert(r.name.clone(), r);
                 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -24,7 +24,7 @@ pub struct Build<'a> {
 
 #[derive(Debug, PartialEq)]
 pub struct Default {
-    pub target: String,
+    pub targets: Vec<String>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -236,11 +236,13 @@ impl<'a> Parser<'a> {
     }
 
     fn read_default(&mut self) -> ParseResult<Default> {
+        let mut targets = Vec::new();
         let target = match self.read_path()? {
             None => return self.scanner.parse_error("expected path"),
             Some(p) => p,
         };
-        Ok(Default { target })
+        targets.push(target);
+        Ok(Default { targets })
     }
 
     fn skip_comment(&mut self) -> ParseResult<()> {
@@ -397,7 +399,7 @@ mod tests {
         assert_eq!(
             ast,
             Statement::Default(Default {
-                target: "f:oo".to_string()
+                targets: vec!["f:oo".to_string()]
             })
         );
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -3,11 +3,13 @@
 use crate::eval::{EvalPart, EvalString, LazyVars, Vars};
 use crate::scanner::{ParseError, ParseResult, Scanner};
 
+#[derive(Debug, PartialEq)]
 pub struct Rule {
     pub name: String,
     pub vars: LazyVars,
 }
 
+#[derive(Debug, PartialEq)]
 pub struct Build<'a> {
     pub rule: &'a str,
     pub line: usize,
@@ -20,15 +22,18 @@ pub struct Build<'a> {
     pub vars: LazyVars,
 }
 
+#[derive(Debug, PartialEq)]
 pub struct Default<'a> {
     pub target: &'a str,
 }
 
+#[derive(Debug, PartialEq)]
 pub struct Pool<'a> {
     pub name: &'a str,
     pub depth: usize,
 }
 
+#[derive(Debug, PartialEq)]
 pub enum Statement<'a> {
     Rule(Rule),
     Build(Build<'a>),
@@ -386,9 +391,6 @@ mod tests {
     #[test]
     fn test_parse_default() {
         let ast = must_read("default foo\n");
-        match ast {
-            Statement::Default(Default { target }) => assert_eq!(target, "foo"),
-            _ => assert!(false),
-        }
+        assert_eq!(ast, Statement::Default(Default { target: "foo" }));
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -20,6 +20,10 @@ pub struct Build<'a> {
     pub vars: LazyVars,
 }
 
+pub struct Default<'a> {
+    pub target: &'a str,
+}
+
 pub struct Pool<'a> {
     pub name: &'a str,
     pub depth: usize,
@@ -28,7 +32,7 @@ pub struct Pool<'a> {
 pub enum Statement<'a> {
     Rule(Rule),
     Build(Build<'a>),
-    Default(&'a str),
+    Default(Default<'a>),
     Include(String),
     Subninja(String),
     Pool(Pool<'a>),
@@ -64,7 +68,7 @@ impl<'a> Parser<'a> {
                     match ident {
                         "rule" => return Ok(Some(Statement::Rule(self.read_rule()?))),
                         "build" => return Ok(Some(Statement::Build(self.read_build()?))),
-                        "default" => return Ok(Some(Statement::Default(self.read_ident()?))),
+                        "default" => return Ok(Some(Statement::Default(self.read_default()?))),
                         "include" => {
                             let path = match self.read_path()? {
                                 None => return self.scanner.parse_error("expected path"),
@@ -224,6 +228,11 @@ impl<'a> Parser<'a> {
             order_only_ins,
             vars,
         })
+    }
+
+    fn read_default(&mut self) -> ParseResult<Default<'a>> {
+        let target = self.read_ident()?;
+        Ok(Default { target })
     }
 
     fn skip_comment(&mut self) -> ParseResult<()> {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -363,3 +363,32 @@ impl<'a> Parser<'a> {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn must_read<'a>(s: &'a str) -> Statement<'a> {
+        let scanner = Scanner::new(s);
+        let mut parser = Parser::new(scanner);
+        match parser.read() {
+            Err(err) => {
+                println!("{}", parser.format_parse_error("test", err));
+                panic!("failed parse");
+            }
+            Ok(None) => {
+                panic!("unexpected eof");
+            }
+            Ok(Some(d)) => d,
+        }
+    }
+
+    #[test]
+    fn test_parse_default() {
+        let ast = must_read("default foo\n");
+        match ast {
+            Statement::Default(Default { target }) => assert_eq!(target, "foo"),
+            _ => assert!(false),
+        }
+    }
+}

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -237,11 +237,14 @@ impl<'a> Parser<'a> {
 
     fn read_default(&mut self) -> ParseResult<Default> {
         let mut targets = Vec::new();
-        let target = match self.read_path()? {
-            None => return self.scanner.parse_error("expected path"),
-            Some(p) => p,
-        };
-        targets.push(target);
+        while let Some(target) = self.read_path()? {
+            targets.push(target);
+            self.scanner.skip_spaces();
+        }
+        if targets.is_empty() {
+          return self.scanner.parse_error("expected path");
+        }
+        self.scanner.expect('\n')?;
         Ok(Default { targets })
     }
 
@@ -395,11 +398,11 @@ mod tests {
 
     #[test]
     fn test_parse_default() {
-        let ast = must_read("default f$:oo\n");
+        let ast = must_read("default f$:oo bar \n");
         assert_eq!(
             ast,
             Statement::Default(Default {
-                targets: vec!["f:oo".to_string()]
+                targets: vec!["f:oo".to_string(), "bar".to_string()]
             })
         );
     }


### PR DESCRIPTION
* parse arg to `default` as path, not as ident
* allow more than one path after `default`