### PR TITLE
launch sh via absolute path /bin/sh

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -54,7 +54,7 @@ fn read_depfile(path: &str) -> anyhow::Result<Vec<String>> {
 /// Executes a build task as a subprocess.
 /// Returns an Err() if we failed outside of the process itself.
 fn run_task(cmdline: &str, depfile: Option<&str>) -> anyhow::Result<TaskResult> {
-    let mut cmd = std::process::Command::new("sh")
+    let mut cmd = std::process::Command::new("/bin/sh")
         .arg("-c")
         .arg(cmdline)
         .output()?;


### PR DESCRIPTION
while comparing syscall traces between ninja and n2, i noticed that
n2 tried to launch `sh` at every entry in my PATH.

---

Not sure if this was intentional previously. But seems bad for build determinism to rely on env vars such as PATH to decide which build commands to run, so maybe it was unintentional?