### PR TITLE
Disable jemalloc on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ libc = "0.2"
 kernel32-sys = "0.2.2"
 winapi = { version = "0.3.6", features = [ "processenv", "consoleapi", "synchapi" ] }
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
+[target.'cfg(not(windows))'.dependencies]
 jemallocator = "0.3.2"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,9 @@ mod task;
 pub mod trace;
 pub mod work;
 
-#[cfg(not(target_env = "msvc"))]
+#[cfg(not(windows))]
 use jemallocator::Jemalloc;
 
-#[cfg(not(target_env = "msvc"))]
+#[cfg(not(windows))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;


### PR DESCRIPTION
Fixes https://github.com/evmar/n2/issues/19

I don't really know the performance implications of this, but as mentioned in the issue, the intention might have been to not use jemalloc on Windows anyway, and it might be a smaller perf gain than it was when introduced. 