### PR TITLE
guard process creation with a mutex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +110,7 @@ dependencies = [
  "getopts",
  "jemallocator",
  "kernel32-sys",
+ "lazy_static",
  "libc",
  "tempfile",
  "winapi 0.3.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 getopts = "0.2"
 anyhow = "1.0"
 libc = "0.2"
+lazy_static = "1.4.0"
 
 [target.'cfg(windows)'.dependencies]
 kernel32-sys = "0.2.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,10 @@ mod task;
 pub mod trace;
 pub mod work;
 
+#[cfg(unix)]
+#[macro_use]
+extern crate lazy_static;
+
 #[cfg(not(target_env = "msvc"))]
 use jemallocator::Jemalloc;
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -26,7 +26,10 @@ fn print_output(out: &std::process::Output) {
 fn assert_output_contains(out: &std::process::Output, text: &str) {
     let out = std::str::from_utf8(&out.stdout).unwrap();
     if !out.contains(text) {
-        panic!("assertion failed; expected output to contain {:?}", text);
+        panic!(
+            "assertion failed; expected output to contain {:?} but got {}",
+            text, out
+        );
     }
 }
 


### PR DESCRIPTION
Fixes an fd leak on all unix systems that don't have pipe2.
As of today, that's all unix systems that are not dragonfly bsd,
freebsd, linux, netbsd, openbsd, or redox -- in particular, macOS.

Fixes #14.