### PR TITLE
refactor progress around task completion

### DIFF
--- a/src/work.rs
+++ b/src/work.rs
@@ -671,7 +671,7 @@ impl<'a> Work<'a> {
                     build.depfile.clone(),
                     build.rspfile.clone(),
                 );
-                self.progress.task_state(id, build, BuildState::Running);
+                self.progress.task_state(id, build, None);
                 made_progress = true;
             }
 
@@ -711,20 +711,8 @@ impl<'a> Work<'a> {
                 t.write_complete(desc, task.tid + 1, task.span.0, task.span.1);
             });
 
-            self.progress.task_state(
-                task.buildid,
-                build,
-                if task.result.termination == task::Termination::Success {
-                    BuildState::Done
-                } else {
-                    BuildState::Failed
-                },
-            );
-            self.progress.completed(
-                build,
-                task.result.termination == task::Termination::Success,
-                &task.result.output,
-            );
+            self.progress
+                .task_state(task.buildid, build, Some(&task.result));
             match task.result.termination {
                 task::Termination::Failure => {
                     if self.keep_going > 0 {


### PR DESCRIPTION
Fixes a TODO around the progress API in the presence of keep-going flag.
Instead of two separate calls for task state change and task completion,
there's now one shared call for task start and finish, and it takes the
full TaskResult struct as a param.  This lets progress see the 'interrupted'
state of the task.