### PR TITLE
Support "fake ninja compat" on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,14 @@ $ cargo build --release
 $ ./target/release/n2 -C some/build/dir
 ```
 
-When CMake executes Ninja it expects some particular Ninja behaviors.  n2
-emulates these behaviors when invoked as `ninja`, so to use it with CMake
-you can `ln -s path/to/n2 ninja` to create a symlink named `ninja` somewhere in
-your `$PATH` such that CMake can discover it.
+When CMake executes Ninja it expects some particular Ninja behaviors. n2
+emulates these behaviors when invoked as `ninja`. To use n2 with CMake you can
+create a symlink:
+- UNIX: `ln -s path/to/n2 ninja`
+- Windows(cmd): `mklink ninja.exe path\to\n2`
+- Windows(PowerShell): `New-Item -Type Symlink ninja.exe -Target path\to\n2`
+
+somewhere in your `$PATH`, such that CMake can discover it.
 
 ## More reading
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,6 +1,7 @@
 extern crate getopts;
 
 use anyhow::anyhow;
+use std::env;
 use std::path::Path;
 
 use crate::{load, progress::ConsoleProgress, trace, work};
@@ -95,8 +96,8 @@ fn use_fancy_terminal() -> bool {
 
 fn run_impl() -> anyhow::Result<i32> {
     let args: Vec<_> = std::env::args().collect();
-    let fake_ninja_compat =
-        Path::new(&args[0]).file_name().unwrap() == std::ffi::OsStr::new("ninja");
+    let fake_ninja_compat = Path::new(&args[0]).file_name().unwrap()
+        == std::ffi::OsStr::new(&format!("ninja{}", env::consts::EXE_SUFFIX));
 
     // Ninja uses available processors + a constant, but I don't think the
     // difference matters too much.


### PR DESCRIPTION
On Windows the Symlink and therefore also the `file_name()` is called `ninja.exe`