### PR TITLE
windows wip

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 kernel32-sys = "0.2.2"
-winapi = { version = "0.3.6", features = [ "processenv", "consoleapi", "synchapi" ] }
+winapi = { version = "0.3.6", features = [ "consoleapi", "namedpipeapi", "processenv", "synchapi" ] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = "0.3.2"

--- a/src/task.rs
+++ b/src/task.rs
@@ -150,8 +150,10 @@ fn run_command(cmdline: &str) -> anyhow::Result<TaskResult> {
     // std::process::Command can't take a string and pass it through to CreateProcess unchanged,
     // so call that ourselves.
 
-    // TODO: Set this to just 0 for console pool jobs.
-    let process_flags = winapi::um::winbase::CREATE_NEW_PROCESS_GROUP;
+    // TODO: Set this to true  console pool jobs once support for that is implemented.
+    let is_in_console_pool = false;
+
+    let process_flags = if is_in_console_pool { 0 } else { winapi::um::winbase::CREATE_NEW_PROCESS_GROUP};
 
     let mut startup_info = zeroed_startupinfo();
     startup_info.cb = std::mem::size_of::<winapi::um::processthreadsapi::STARTUPINFOA>() as u32;


### PR DESCRIPTION
not ready for merging, doesn't even build iirc. also leaks handles, see TODO.

I wrote this 1.5 weeks ago and haven't had time to work more on it since then, so uploading in case someone else wants to continue.

makes subprocesses's stdout and stderr write to the same pipe. that means possibly interleaved output. that matches ninja's behavior, but is worse than n2's non-win behavior which gets stdout and stderr independently from subprocesses and then appends them (so they're guaranteed not to interleave).

(else i'll get back to it sometime soon, hopefully.)