### PR TITLE
Fixing acquiring ThreadIds when extending the vector

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -245,7 +245,7 @@ fn run_command(cmdline: &str) -> anyhow::Result<TaskResult> {
 }
 
 /// Tracks faked "thread ids" -- integers assigned to build tasks to track
-/// paralllelism in perf trace output.
+/// parallelism in perf trace output.
 struct ThreadIds {
     /// An entry is true when claimed, false or nonexistent otherwise.
     slots: Vec<bool>,
@@ -263,7 +263,7 @@ impl ThreadIds {
             }
             None => {
                 let idx = self.slots.len();
-                self.slots.push(false);
+                self.slots.push(true);
                 idx
             }
         }


### PR DESCRIPTION
This should fix https://github.com/evmar/n2/issues/48
<img width="1277" alt="Screenshot 2022-04-13 at 22 27 24" src="https://user-images.githubusercontent.com/351085/163273383-ff08c65d-1059-4656-875d-63b900b449a8.png">

Also fix a nearby typo paralllelism -> parallelism