### PR TITLE
Skip spaces between target and colon in depfile

### DIFF
--- a/src/depfile.rs
+++ b/src/depfile.rs
@@ -61,6 +61,7 @@ pub fn parse<'a>(scanner: &mut Scanner<'a>) -> ParseResult<Deps<'a>> {
         None => return scanner.parse_error("expected file"),
         Some(o) => o,
     };
+    scanner.skip_spaces();
     scanner.expect(':')?;
     let mut deps = Vec::new();
     while let Some(p) = read_path(scanner)? {

--- a/src/depfile.rs
+++ b/src/depfile.rs
@@ -121,4 +121,12 @@ mod tests {
         assert_eq!(deps.target, "build/browse.o");
         assert_eq!(deps.deps.len(), 1);
     }
+
+    #[test]
+    fn test_parse_spaces_before_colon() {
+        let mut file = b"build/browse.o   : src/browse.cc".to_vec();
+        let deps = must_parse(&mut file);
+        assert_eq!(deps.target, "build/browse.o");
+        assert_eq!(deps.deps.len(), 1);
+    }
 }


### PR DESCRIPTION
When using CMake with CUDA targets, CMake adds an extra space for some reason: https://github.com/travbid/n2-cuda/blob/c152b2ffebaef90c03e45ea04dae2ef5d4299085/build/CMakeFiles/foo.dir/foo.cu.o.d#L1
(generated with CMake 3.20.4 on Ubuntu)

This causes n2 to fail during build:
```bash
~/Projects/n2-cuda/build$ n2
Re-running CMake...
-- Configuring done
-- Generating done
-- Build files have been written to: /home/travers/Projects/n2-cuda/build
failed: Building CUDA object CMakeFiles/foo.dir/foo.cu.o
parse error: expected ':', got ' '
CMakeFiles/foo.dir/foo.cu.o.d:1: CMakeFiles/foo.dir/foo.cu.o : ../foo.cu ...
                                                            ^
```
Ninja doesn't have an issue with these spaces - should n2 also handle them, or would you prefer this to be fixed in CMake?