### PR TITLE
Pleasing clippy + UB fix

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -211,11 +211,11 @@ impl<'a> Reader<'a> {
 
     fn read_str(&mut self, len: usize) -> std::io::Result<String> {
         let mut buf = Vec::with_capacity(len);
-        // Safety: buf contents are uninitialized here, but we never read them
-        // before initialization.
-        // TODO: clippy says this is still UB, yuck.
-        unsafe { buf.set_len(len) };
-        self.r.read_exact(buf.as_mut_slice())?;
+        let bytes_read = Read::take(&mut self.r, len as u64).read_to_end(&mut buf)?;
+        if bytes_read < len {
+            return Err(std::io::ErrorKind::UnexpectedEof.into());
+        }
+        debug_assert_eq!(bytes_read, len);
         Ok(unsafe { String::from_utf8_unchecked(buf) })
     }
 

--- a/src/densemap.rs
+++ b/src/densemap.rs
@@ -17,7 +17,7 @@ impl<K, V> Default for DenseMap<K, V> {
     fn default() -> Self {
         DenseMap {
             vec: Vec::default(),
-            key_type: PhantomData::default(),
+            key_type: PhantomData,
         }
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -104,10 +104,8 @@ impl BuildOuts {
         for (i, &id) in self.ids.iter().enumerate() {
             if !self.ids[0..i].iter().any(|&prev| prev == id) {
                 ids.push(id);
-            } else {
-                if i < self.explicit {
-                    self.explicit -= 1;
-                }
+            } else if i < self.explicit {
+                self.explicit -= 1;
             }
         }
         self.ids = ids;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-use n2;
-
 fn main() {
     let exit_code = match n2::run::run() {
         Ok(code) => code,

--- a/src/smallmap.rs
+++ b/src/smallmap.rs
@@ -35,7 +35,7 @@ impl<K: PartialEq, V> SmallMap<K, V> {
                 return Some(v);
             }
         }
-        return None;
+        None
     }
 
     pub fn iter(&self) -> std::slice::Iter<(K, V)> {

--- a/src/work.rs
+++ b/src/work.rs
@@ -140,11 +140,8 @@ impl BuildStates {
         let prev = *mprev;
         // println!("{:?} {:?}=>{:?}", id, prev, state);
         *mprev = state;
-        match prev {
-            BuildState::Running => {
-                self.get_pool(build).unwrap().running -= 1;
-            }
-            _ => {}
+        if let BuildState::Running = prev {
+            self.get_pool(build).unwrap().running -= 1;
         };
         if prev != BuildState::Unknown {
             self.counts.add(prev, -1);

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -8,7 +8,6 @@ pub fn n2_binary() -> std::path::PathBuf {
         .parent()
         .expect("binary directory")
         .join("n2")
-        .to_path_buf()
 }
 
 pub fn n2_command(args: Vec<&str>) -> std::process::Command {


### PR DESCRIPTION
Two commits.

First is just random insignificant stuff reported by Clippy.

The second is a fix to UB reported by Clippy.
The problem there was getting a `&mut [u8]` to an uninitiated buffer to read into it using `read_exact`. Even though it seems to be fine, since we don't read from the buffer before writing to it, Rust relies on `&mut` referencing valid-to-read memory, so this is technically UB. Sadly, no method would accept `*mut u8`, but I found one that accept `&mut Vec<u8>`: `read_to_end`. Sounds perfect. One small issue: it reads until EOF. Luckily there's a `take` method that wraps a reader and reads at most N bytes, giving EOF afterwards. But it wants to move its first arguments so instead of `self.r.take(...`, which desugars to `Read::take(self.r, ...`, we have to write `Read::take(&mut self.r, ...`. And, finally, a check to ensure we have read enough bytes, because we don't have `read_exact` checking it for us anymore.