### PR TITLE
Sacrificy some compile time for runtime performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,5 @@ tempfile = "3.3.0"
 
 [profile.release]
 debug = true
+lto = "fat"
+codegen-units = 1


### PR DESCRIPTION
Does 2 things:
1. Enables fat LTO for release builds (instead of thin LTO, which is the default for release builds (or is it no LTO at all?)). This is slightly slower to compile but results in a slightly faster and somewhat smaller binary. (The two optimizations combined reduced the binary size from 1307 to 1213 KiB when stripped for me).
2. Sets `codegen-units` to 1. This prevents `rustc` from doing any parallel compilation inside of a crate (cargo still compiles different crates in parallel), which results in a faster binary at the cost of a worsely (badlier?) parallelized compilation. Doesn't really matter too much for this project, because all the crates are relatively small, and the only big thing is `jemalloc` which spends most of its time building C code, which isn't affected by `codegen-units`.

There are [other adjustable parameters](https://doc.rust-lang.org/cargo/reference/profiles.html), which I didn't touch in this PR.
The only noteworthy, IMO, is
```toml
panic = "abort"
```
to opt out of stack unwinding in case of panics. Pros: essentially `noexcept`s the entire program. Cons: no destructors are run, so buffers will probably not get flushed.

It is also possible to set up different profiles with different optimization settings (see the link above), but I don't know if this project needs those.
