### PR TITLE
Minor CLI improvements

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ fn main() {
     let exit_code = match n2::run::run() {
         Ok(code) => code,
         Err(err) => {
-            println!("n2: error: {}", err);
+            eprintln!("n2: error: {}", err);
             1
         }
     };

--- a/src/run.rs
+++ b/src/run.rs
@@ -122,8 +122,12 @@ fn run_impl() -> anyhow::Result<i32> {
         explain: false,
     };
 
-    if fake_ninja_compat && args.version {
-        println!("1.10.2");
+    if args.version {
+        if fake_ninja_compat {
+            println!("1.10.2");
+        } else {
+            println!("{}", env!("CARGO_PKG_VERSION"));
+        }
         return Ok(0);
     }
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -10,7 +10,7 @@ fn empty_file() -> anyhow::Result<()> {
     space.write("build.ninja", "")?;
     let out = space.run(&mut n2_command(vec![]))?;
     assert_eq!(
-        std::str::from_utf8(&out.stdout)?,
+        std::str::from_utf8(&out.stderr)?,
         "n2: error: no path specified and no default\n"
     );
     Ok(())


### PR DESCRIPTION
1. Print errors to stderr instead of stdout
2. React to `--version` even when running outside of ninja compatibility mode. In this case, report the actual version taken from `Cargo.toml`

It is also possible to switch to a fancy [`ExitCode`](https://doc.rust-lang.org/1.61.0/std/process/struct.ExitCode.html), which can be returned from `main()` instead of having to call `std::process::exit(status_code)`, but that would mean bumping MSRV from 1.59 to 1.61, so ...