### PR TITLE
fix clippy: UB

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -207,11 +207,7 @@ impl<'a> Reader<'a> {
     }
 
     fn read_str(&mut self, len: usize) -> std::io::Result<String> {
-        let mut buf = Vec::with_capacity(len);
-        // Safety: buf contents are uninitialized here, but we never read them
-        // before initialization.
-        // TODO: clippy says this is still UB, yuck.
-        unsafe { buf.set_len(len) };
+        let mut buf = vec![0; len];
         self.r.read_exact(buf.as_mut_slice())?;
         Ok(unsafe { String::from_utf8_unchecked(buf) })
     }


### PR DESCRIPTION
When I run `cargo clippy`, I met below:
```
error: calling `set_len()` immediately after reserving a buffer creates uninitialized values
   --> src/db.rs:210:9
    |
210 |         let mut buf = Vec::with_capacity(len);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
214 |         unsafe { buf.set_len(len) };
    |                  ^^^^^^^^^^^^^^^^
    |
    = help: initialize the buffer or wrap the content in `MaybeUninit`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninit_vec
    = note: `#[deny(clippy::uninit_vec)]` on by default
```
This PR fixes it.