### PR TITLE
Mark new db as fresh

### DIFF
--- a/src/load.rs
+++ b/src/load.rs
@@ -185,6 +185,8 @@ impl Loader {
 /// State loaded by read().
 pub struct State {
     pub graph: graph::Graph,
+    /// True if we think this is the first time n2 has been run for this build directory.
+    pub fresh: bool,
     pub db: db::Writer,
     pub hashes: graph::Hashes,
     pub default: Vec<FileId>,
@@ -199,12 +201,13 @@ pub fn read(build_filename: &str) -> anyhow::Result<State> {
         loader.read_file(id)
     })?;
     let mut hashes = graph::Hashes::default();
-    let db = trace::scope("db::open", || {
+    let (fresh, db) = trace::scope("db::open", || {
         db::open(".n2_db", &mut loader.graph, &mut hashes)
     })
     .map_err(|err| anyhow!("load .n2_db: {}", err))?;
     Ok(State {
         graph: loader.graph,
+        fresh,
         db,
         hashes,
         default: loader.default,

--- a/src/run.rs
+++ b/src/run.rs
@@ -33,9 +33,12 @@ fn build(
 
     let mut tasks_finished = 0;
 
-    // Attempt to rebuild build.ninja.
     let build_file_target = work.lookup(&build_filename);
+    // Attempt to rebuild build.ninja.
     if let Some(target) = build_file_target {
+        if state.fresh {
+            work.adopt = true;
+        }
         work.want_file(target)?;
         match trace::scope("work.run", || work.run())? {
             None => return Ok(None),


### PR DESCRIPTION
This implements an idea from #40, where on the first n2 run we assume the build.ninja is up to date.