### PR TITLE
record phony build task result as well

### DIFF
--- a/src/work.rs
+++ b/src/work.rs
@@ -569,6 +569,14 @@ impl<'a> Work<'a> {
         // A phony build can never be dirty.
         let phony = build.cmdline.is_none();
         if phony {
+            self.record_finished(
+                id,
+                task::TaskResult {
+                    termination: process::Termination::Success,
+                    output: vec![],
+                    discovered_deps: None,
+                },
+            )?;
             return Ok(false);
         }
 

--- a/tests/e2e/basic.rs
+++ b/tests/e2e/basic.rs
@@ -292,3 +292,26 @@ build out: custom
     assert_output_contains(&out, "echo 123 hello 123");
     Ok(())
 }
+
+// Repro for issue #84.
+#[test]
+fn phony_depends() -> anyhow::Result<()> {
+    let space = TestSpace::new()?;
+    space.write(
+        "build.ninja",
+        &[
+            "
+rule touch
+  command = touch outfile",
+            "
+build out1: touch
+build out2: phony out1
+build out3: phony out2
+",
+        ]
+        .join("\n"),
+    )?;
+    space.run_expect(&mut n2_command(vec!["out3"]))?;
+    space.read("outfile")?;
+    Ok(())
+}


### PR DESCRIPTION
This pull request fixes a bug where if a phony `build` depends on another phony `build`, `n2` will fail to resolve the dependency.

-------

When running `n2` with the following `build.ninja` file, `n2` will report "n2: error: used generated file A, but has no dependency path to it," while `ninja` will correctly output `[1/1] Checking`.

```ninja
rule CUSTOM_COMMAND
  command = $COMMAND
  description = $DESC

build A: phony B
build B: CUSTOM_COMMAND
  COMMAND = touch file
  DESC = Checking
build check: phony A

default check
```

This pattern can be observed in several CMake-based projects.

If the terminal phony `rule` specifies no explicit and actual output file and another phony `rule` transitively depends on it, `n2` will fail to resolve the dependency.
However, `n2 A` will still work as expected.

--------

This pull request is a very quick and dirty solution that I have found, and I hope you can develop a better one since this approach just mindlessly updates all the `phony` build states, which may impact performance.