### PR TITLE
Evaluate build paths in the context of the build's bindings

### DIFF
--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -22,14 +22,6 @@ pub fn bench_canon(c: &mut Criterion) {
     });
 }
 
-struct NoOpLoader {}
-impl n2::parse::Loader for NoOpLoader {
-    type Path = ();
-    fn path(&mut self, _path: &mut str) -> Self::Path {
-        ()
-    }
-}
-
 fn generate_build_ninja() -> Vec<u8> {
     let mut buf: Vec<u8> = Vec::new();
     write!(buf, "rule cc\n    command = touch $out",).unwrap();
@@ -46,14 +38,13 @@ fn generate_build_ninja() -> Vec<u8> {
 }
 
 fn bench_parse_synthetic(c: &mut Criterion) {
-    let mut loader = NoOpLoader {};
     let mut input = generate_build_ninja();
     input.push(0);
     c.bench_function("parse synthetic build.ninja", |b| {
         b.iter(|| {
             let mut parser = n2::parse::Parser::new(&input);
             loop {
-                if parser.read(&mut loader).unwrap().is_none() {
+                if parser.read().unwrap().is_none() {
                     break;
                 }
             }
@@ -62,13 +53,12 @@ fn bench_parse_synthetic(c: &mut Criterion) {
 }
 
 fn bench_parse_file(c: &mut Criterion, mut input: Vec<u8>) {
-    let mut loader = NoOpLoader {};
     input.push(0);
     c.bench_function("parse benches/build.ninja", |b| {
         b.iter(|| {
             let mut parser = n2::parse::Parser::new(&input);
             loop {
-                if parser.read(&mut loader).unwrap().is_none() {
+                if parser.read().unwrap().is_none() {
                     break;
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ mod depfile;
 mod eval;
 mod graph;
 mod hash;
-mod load;
+pub mod load;
 pub mod parse;
 mod process;
 #[cfg(unix)]

--- a/src/load.rs
+++ b/src/load.rs
@@ -43,7 +43,7 @@ impl<'a> eval::Env for BuildImplicitVars<'a> {
 
 /// Internal state used while loading.
 #[derive(Default)]
-struct Loader {
+pub struct Loader {
     graph: graph::Graph,
     default: Vec<FileId>,
     /// rule name -> list of (key, val)
@@ -64,7 +64,7 @@ impl parse::Loader for Loader {
 }
 
 impl Loader {
-    fn new() -> Self {
+    pub fn new() -> Self {
         let mut loader = Loader::default();
 
         loader.rules.insert("phony".to_owned(), SmallMap::default());
@@ -167,7 +167,7 @@ impl Loader {
         self.parse(path, &bytes)
     }
 
-    fn parse(&mut self, path: PathBuf, bytes: &[u8]) -> anyhow::Result<()> {
+    pub fn parse(&mut self, path: PathBuf, bytes: &[u8]) -> anyhow::Result<()> {
         let filename = std::rc::Rc::new(path);
 
         let mut parser = parse::Parser::new(&bytes);

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -33,6 +33,16 @@ impl<'a> Scanner<'a> {
     pub fn peek(&self) -> char {
         unsafe { *self.buf.get_unchecked(self.ofs) as char }
     }
+    pub fn peek_newline(&self) -> bool {
+        if self.peek() == '\n' {
+            return true;
+        }
+        if self.ofs >= self.buf.len() - 1 {
+            return false;
+        }
+        let peek2 = unsafe { *self.buf.get_unchecked(self.ofs + 1) as char };
+        self.peek() == '\r' && peek2 == '\n'
+    }
     pub fn next(&mut self) {
         if self.peek() == '\n' {
             self.line += 1;

--- a/tests/e2e/basic.rs
+++ b/tests/e2e/basic.rs
@@ -349,3 +349,105 @@ build out: my_rule
     assert_output_contains(&out, "unexpected variable \"my_var\"");
     Ok(())
 }
+
+#[cfg(unix)]
+#[test]
+fn deps_evaluate_build_bindings() -> anyhow::Result<()> {
+    let space = TestSpace::new()?;
+    space.write(
+        "build.ninja",
+        "
+rule touch
+    command = touch $out
+rule copy
+    command = cp $in $out
+build foo: copy ${my_dep}
+    my_dep = bar
+build bar: touch
+",
+    )?;
+    space.run_expect(&mut n2_command(vec!["foo"]))?;
+    space.read("foo")?;
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn looks_up_values_from_build() -> anyhow::Result<()> {
+    let space = TestSpace::new()?;
+    space.write(
+        "build.ninja",
+        "
+rule copy_rspfile
+    command = cp $out.rsp $out
+    rspfile = $out.rsp
+
+build foo: copy_rspfile
+    rspfile_content = Hello, world!
+",
+    )?;
+    space.run_expect(&mut n2_command(vec!["foo"]))?;
+    assert_eq!(space.read("foo")?, b"Hello, world!");
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn build_bindings_arent_recursive() -> anyhow::Result<()> {
+    let space = TestSpace::new()?;
+    space.write(
+        "build.ninja",
+        "
+rule write_file
+    command = echo $my_var > $out
+
+build foo: write_file
+    my_var = Hello,$my_var_2 world!
+    my_var_2 = my_var_2_value
+",
+    )?;
+    space.run_expect(&mut n2_command(vec!["foo"]))?;
+    assert_eq!(space.read("foo")?, b"Hello, world!\n");
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn empty_variable_binding() -> anyhow::Result<()> {
+    let space = TestSpace::new()?;
+    space.write(
+        "build.ninja",
+        "
+empty_var =
+
+rule write_file
+    command = echo $my_var > $out
+
+build foo: write_file
+    my_var = Hello,$empty_var world!
+",
+    )?;
+    space.run_expect(&mut n2_command(vec!["foo"]))?;
+    assert_eq!(space.read("foo")?, b"Hello, world!\n");
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn empty_build_variable() -> anyhow::Result<()> {
+    let space = TestSpace::new()?;
+    space.write(
+        "build.ninja",
+        "
+rule write_file
+    command = echo $my_var > $out
+
+build foo: write_file
+    empty =
+    my_var = Hello, world!
+",
+    )?;
+    space.run_expect(&mut n2_command(vec!["foo"]))?;
+    assert_eq!(space.read("foo")?, b"Hello, world!\n");
+    Ok(())
+}

--- a/tests/e2e/basic.rs
+++ b/tests/e2e/basic.rs
@@ -330,3 +330,22 @@ fn builddir() -> anyhow::Result<()> {
     space.read("foo/.n2_db")?;
     Ok(())
 }
+
+#[test]
+fn bad_rule_variable() -> anyhow::Result<()> {
+    let space = TestSpace::new()?;
+    space.write(
+        "build.ninja",
+        "
+rule my_rule
+    command = touch $out
+    my_var = foo
+
+build out: my_rule
+",
+    )?;
+
+    let out = space.run(&mut n2_command(vec!["out"]))?;
+    assert_output_contains(&out, "unexpected variable \"my_var\"");
+    Ok(())
+}


### PR DESCRIPTION
This fixes an incompatibility with ninja.

I've also refactored Env to make it clearer and remove the TODO(#83), but I actually think we could do signifigant further cleanup. Only rules should require EvalStrings, global variables and build bindings can be evaluated as soon as they're read, although maybe that would change with subninjas. Also, rules currently parse their variables as EvalString<String>, but I think that could be changed to EvalString<&'text str> if we hold onto the byte buffers of all the included files until the parsing is done.

Fixes #91 and #39.