### PR TITLE
Canonicalize paths to '.' instead of an empty string

### DIFF
--- a/tests/e2e/directories.rs
+++ b/tests/e2e/directories.rs
@@ -1,0 +1,24 @@
+use crate::e2e::*;
+
+#[cfg(unix)]
+#[test]
+fn dep_on_current_directory() -> anyhow::Result<()> {
+    let space = TestSpace::new()?;
+    space.write(
+        "build.ninja",
+        "
+rule list_files
+    command = ls $in > $out
+
+build out: list_files .
+",
+    )?;
+    space.write("foo", "")?;
+    space.run_expect(&mut n2_command(vec!["out"]))?;
+    assert_eq!(space.read("out")?, b"build.ninja\nfoo\nout\n");
+    space.write("foo2", "")?;
+    space.run_expect(&mut n2_command(vec!["out"]))?;
+    assert_eq!(space.read("out")?, b"build.ninja\nfoo\nfoo2\nout\n");
+
+    Ok(())
+}

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -1,6 +1,7 @@
 //! Support code for e2e tests, which run n2 as a binary.
 
 mod basic;
+mod directories;
 mod discovered;
 mod missing;
 mod regen;


### PR DESCRIPTION
It's possible to have a ninja dep on '.', meaning the directory that ninja was run from. Previously, canon_path_fast would canonicalize this to an empty string, which would cause stats and other opterations to fail.

This was found when running the android codebase with n2.