### PR TITLE
Wait for out instead of regular_input

### DIFF
--- a/tests/e2e/validations.rs
+++ b/tests/e2e/validations.rs
@@ -43,7 +43,7 @@ rule build_fast
 build out: build_fast regular_input |@ validation_input
 build regular_input: build_fast
 build validation_input: build_slow
-  wait_for = regular_input
+  wait_for = out
 ",
     )?;
     space.run_expect(&mut n2_command(vec!["out"]))?;


### PR DESCRIPTION
The test is supposed to ensure that out builds before validation_input.

For #102 