### PR TITLE
Minor performance improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,7 @@ dependencies = [
  "filetime",
  "jemallocator",
  "libc",
+ "rustc-hash",
  "tempfile",
  "windows-sys 0.48.0",
 ]
@@ -530,6 +531,12 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ description = "a ninja compatible build system"
 anyhow = "1.0"
 argh = "0.1.10"
 libc = "0.2"
+rustc-hash = "1.1.0"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.48"

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,5 +1,4 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use n2::parse::Loader;
 use std::{io::Write, path::PathBuf, str::FromStr};
 
 pub fn bench_canon(c: &mut Criterion) {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,10 +1,11 @@
 //! Represents parsed Ninja strings with embedded variable references, e.g.
 //! `c++ $in -o $out`, and mechanisms for expanding those into plain strings.
 
+use rustc_hash::FxHashMap;
+
 use crate::smallmap::SmallMap;
 use std::borrow::Borrow;
 use std::borrow::Cow;
-use std::collections::HashMap;
 
 /// An environment providing a mapping of variable name to variable value.
 /// This represents one "frame" of evaluation context, a given EvalString may
@@ -121,7 +122,7 @@ impl EvalString<&str> {
 
 /// A single scope's worth of variable definitions.
 #[derive(Debug, Default)]
-pub struct Vars<'text>(HashMap<&'text str, String>);
+pub struct Vars<'text>(FxHashMap<&'text str, String>);
 
 impl<'text> Vars<'text> {
     pub fn insert(&mut self, key: &'text str, val: String) {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3,7 +3,8 @@
 
 use crate::smallmap::SmallMap;
 use std::borrow::Borrow;
-use std::{borrow::Cow, collections::HashMap};
+use std::borrow::Cow;
+use std::collections::HashMap;
 
 /// An environment providing a mapping of variable name to variable value.
 /// This represents one "frame" of evaluation context, a given EvalString may

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,5 +1,7 @@
 //! The build graph, a graph between files and commands.
 
+use rustc_hash::FxHashMap;
+
 use crate::{
     densemap::{self, DenseMap},
     hash::BuildHash,
@@ -258,7 +260,7 @@ pub struct Graph {
 #[derive(Default)]
 pub struct GraphFiles {
     pub by_id: DenseMap<FileId, File>,
-    by_name: HashMap<String, FileId>,
+    by_name: FxHashMap<String, FileId>,
 }
 
 impl Graph {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -57,18 +57,6 @@ pub struct Parser<'text> {
     eval_buf: Vec<EvalPart<&'text str>>,
 }
 
-/// Loader maps path strings (as found in build.ninja files) into an arbitrary
-/// "Path" type.  This allows us to canonicalize and convert path strings to
-/// more efficient integer identifiers while we parse, rather than needing to
-/// buffer up many intermediate strings; in fact, parsing uses a single buffer
-/// for all of these.
-pub trait Loader {
-    type Path;
-    /// Convert a path string to a Self::Path type.  For performance reasons
-    /// this may mutate the 'path' param.
-    fn path(&mut self, path: &mut str) -> Self::Path;
-}
-
 impl<'text> Parser<'text> {
     pub fn new(buf: &'text [u8]) -> Parser<'text> {
         Parser {

--- a/src/work.rs
+++ b/src/work.rs
@@ -788,7 +788,7 @@ build b: phony c
 build c: phony a
 ";
         let mut graph = crate::load::parse("build.ninja", file.as_bytes().to_vec())?;
-        let a_id = graph.files.id_from_canonical("a");
+        let a_id = graph.files.id_from_canonical("a".to_owned());
         let mut states = BuildStates::new(graph.builds.next_id(), SmallMap::default());
         let mut stack = Vec::new();
         match states.want_file(&graph, &mut stack, a_id) {


### PR DESCRIPTION
- Pass owned strings to id_from_canonical instead of references
- Precalculate the length of evaluated strings, and reserve space in the result string
- Only hash strings once in id_from_canonical
- Switch some HashMaps to FxHashMaps

These changes give about a 20% performance improvement to bench_load_synthetic, and save a couple seconds off of loading the android ninja files. Most of this is from the switch to FxHashMap, the other changes are only around a 5% improvement.

If you have concerns about any of these commits let me know and I'll take those ones out of the PR.
