### PR TITLE
Parse depfiles with multiple targets

### DIFF
--- a/src/smallmap.rs
+++ b/src/smallmap.rs
@@ -2,7 +2,7 @@
 //! TODO: this may not be needed at all, but the code used this pattern in a
 //! few places so I figured I may as well name it.
 
-use std::borrow::Borrow;
+use std::{borrow::Borrow, fmt::Debug};
 
 /// A map-like object implemented as a list of pairs, for cases where the
 /// number of entries in the map is small.
@@ -48,5 +48,33 @@ impl<K: PartialEq, V> SmallMap<K, V> {
 
     pub fn into_iter(self) -> std::vec::IntoIter<(K, V)> {
         self.0.into_iter()
+    }
+
+    pub fn values(&self) -> impl Iterator<Item = &V> + '_ {
+        self.0.iter().map(|x| &x.1)
+    }
+}
+
+impl<K: PartialEq, V, const N: usize> std::convert::From<[(K, V); N]> for SmallMap<K, V> {
+    fn from(value: [(K, V); N]) -> Self {
+        let mut result = SmallMap::default();
+        for (k, v) in value {
+            result.insert(k, v);
+        }
+        result
+    }
+}
+
+impl<K: Debug, V: Debug> Debug for SmallMap<K, V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+// Only for tests because it is order-sensitive
+#[cfg(test)]
+impl<K: PartialEq, V: PartialEq> PartialEq for SmallMap<K, V> {
+    fn eq(&self, other: &Self) -> bool {
+        return self.0 == other.0;
     }
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -51,9 +51,9 @@ fn read_depfile(path: &Path) -> anyhow::Result<Vec<String>> {
         .map_err(|err| anyhow!(scanner.format_parse_error(path, err)))?;
     // TODO verify deps refers to correct output
     let deps: Vec<String> = parsed_deps
-        .deps
-        .iter()
-        .map(|&dep| dep.to_string())
+        .values()
+        .flat_map(|x| x.iter())
+        .map(|&dep| dep.to_owned())
         .collect();
     Ok(deps)
 }


### PR DESCRIPTION
This is needed for android. It just treats all the deps of all targets in the depfile as deps for the Build.

In task.rs there is a TODO to verify that the targets refer to the outputs of the Build, but adding that verification breaks the android build. In android's case, there are some depfiles that contain `foo.o: path/to/some/dep.asm` where it should instead be `path/to/foo.o: path/to/some/dep.asm`.

With this change, you can do a full build of android with n2.
