### PR TITLE
Atomic operations are safe actually

### DIFF
--- a/src/signal.rs
+++ b/src/signal.rs
@@ -6,13 +6,11 @@
 
 use std::sync::atomic::AtomicBool;
 
-static mut INTERRUPTED: AtomicBool = AtomicBool::new(false);
+static INTERRUPTED: AtomicBool = AtomicBool::new(false);
 
 #[cfg(unix)]
 extern "C" fn sigint_handler(_sig: libc::c_int) {
-    unsafe {
-        INTERRUPTED.store(true, std::sync::atomic::Ordering::Relaxed);
-    }
+    INTERRUPTED.store(true, std::sync::atomic::Ordering::Relaxed);
     // SA_RESETHAND should clear the handler.
 }
 
@@ -28,5 +26,5 @@ pub fn register_sigint() {
 }
 
 pub fn was_interrupted() -> bool {
-    unsafe { INTERRUPTED.load(std::sync::atomic::Ordering::Relaxed) }
+    INTERRUPTED.load(std::sync::atomic::Ordering::Relaxed)
 }


### PR DESCRIPTION
Atomics in Rust posses "interior mutability", which means that you can change their contents through a `&` without a need for a `&mut`. `load`/`store` do indeed take a `&`.

So the `static` does not have to be `mut`. And as soon as it isn't, taking references to it becomes completely safe. Yay.