### PR TITLE
Bump MSRV to 1.77 & start using cstr literals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: dtolnay/rust-toolchain@1.75.0
+    - uses: dtolnay/rust-toolchain@1.77.2
       with:
         components: rustfmt
     - name: Check formatting

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 repository = "https://github.com/evmar/n2"
 # https://github.com/evmar/n2/issues/74
 # Note: if we bump this, may need to bump .github/workflows/ci.yml version too.
-rust-version = "1.75.0"
+rust-version = "1.77.2"
 description = "a ninja compatible build system"
 
 [dependencies]

--- a/src/process_posix.rs
+++ b/src/process_posix.rs
@@ -166,12 +166,7 @@ pub fn run_command(cmdline: &str, mut output_cb: impl FnMut(&[u8])) -> anyhow::R
 
         let mut actions = PosixSpawnFileActions::new()?;
         // open /dev/null over stdin
-        actions.addopen(
-            0,
-            std::ffi::CStr::from_bytes_with_nul_unchecked(b"/dev/null\0"),
-            libc::O_RDONLY,
-            0,
-        )?;
+        actions.addopen(0, c"/dev/null", libc::O_RDONLY, 0)?;
         // stdout/stderr => pipe
         actions.adddup2(pipe[1], 1)?;
         actions.adddup2(pipe[1], 2)?;
@@ -180,11 +175,11 @@ pub fn run_command(cmdline: &str, mut output_cb: impl FnMut(&[u8])) -> anyhow::R
         actions.addclose(pipe[1])?;
 
         let mut pid: libc::pid_t = 0;
-        let path = std::ffi::CStr::from_bytes_with_nul_unchecked(b"/bin/sh\0");
+        let path = c"/bin/sh";
         let cmdline_nul = std::ffi::CString::new(cmdline).unwrap();
         let argv: [*const libc::c_char; 4] = [
             path.as_ptr(),
-            b"-c\0".as_ptr() as *const _,
+            c"-c".as_ptr(),
             cmdline_nul.as_ptr(),
             std::ptr::null(),
         ];


### PR DESCRIPTION
IDK what the MSRV policy is for n2, but if a bump to a version from April 2024 is fine, then we can write CStr with directly with literals. How cool is that

There was also this thing fixed in 1.77.2 https://blog.rust-lang.org/2024/04/09/cve-2024-24576.html
IDK how much it impacts n2