### PR TITLE
Add hide_success and hide_last_line options

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -174,6 +174,11 @@ pub struct Build {
 
     /// Output files.
     pub outs: BuildOuts,
+
+    /// True if output of command should be hidden on successful completion.
+    pub hide_success: bool,
+    /// True if last line of output should not be shown in status.
+    pub hide_last_line: bool,
 }
 impl Build {
     pub fn new(loc: FileLoc, ins: BuildIns, outs: BuildOuts) -> Self {
@@ -188,6 +193,8 @@ impl Build {
             ins,
             discovered_ins: Vec::new(),
             outs,
+            hide_success: false,
+            hide_last_line: false,
         }
     }
 

--- a/src/load.rs
+++ b/src/load.rs
@@ -158,6 +158,8 @@ impl Loader {
             }),
             _ => bail!("rspfile and rspfile_content need to be both specified"),
         };
+        let hide_success = lookup("hide_success").as_deref() == Some("1");
+        let hide_last_line = lookup("hide_last_line").as_deref() == Some("1");
 
         build.cmdline = cmdline;
         build.desc = desc;
@@ -165,6 +167,8 @@ impl Loader {
         build.parse_showincludes = parse_showincludes;
         build.rspfile = rspfile;
         build.pool = pool;
+        build.hide_success = hide_success;
+        build.hide_last_line = hide_last_line;
 
         self.graph.add_build(build)
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -157,6 +157,8 @@ impl<'text> Parser<'text> {
                     | "rspfile"
                     | "rspfile_content"
                     | "msvc_deps_prefix"
+                    | "hide_success"
+                    | "hide_last_line"
             )
         })?;
         Ok(Rule { name, vars })

--- a/src/progress_fancy.rs
+++ b/src/progress_fancy.rs
@@ -180,7 +180,7 @@ impl FancyState {
         // Show task name, status, and output.
         let buf = &mut self.pending;
         match result.termination {
-            Termination::Success if result.output.is_empty() => {
+            Termination::Success if result.output.is_empty() || build.hide_success => {
                 // Common case: don't show anything.
                 return;
             }

--- a/src/task.rs
+++ b/src/task.rs
@@ -215,6 +215,7 @@ impl Runner {
         let depfile = build.depfile.clone().map(PathBuf::from);
         let rspfile = build.rspfile.clone();
         let parse_showincludes = build.parse_showincludes;
+        let hide_last_line = build.hide_last_line;
 
         let tid = self.tids.claim();
         let tx = self.tx.clone();
@@ -226,7 +227,9 @@ impl Runner {
                 parse_showincludes,
                 rspfile.as_ref(),
                 |line| {
-                    let _ = tx.send(Message::Output((id, line.to_owned())));
+                    if !hide_last_line {
+                        let _ = tx.send(Message::Output((id, line.to_owned())));
+                    }
                 },
             )
             .unwrap_or_else(|err| TaskResult {


### PR DESCRIPTION
This is an implementation of the output suppression I mentioned in https://github.com/evmar/n2/issues/68#issuecomment-1689132964, and is related to https://github.com/evmar/n2/issues/101. We've been using it in our project for the last year or so (1), and have been very happy with the balance of immediate output without overwhelming amounts of text being shown (2). I present it here not for immediate inclusion, but to rekindle discussion, as functionality like this would be nice to have in a stock n2 in the future.

(1) I've just rebased our version over the latest code

(2) One minor papercut is that certain terminal formatting codes can sometimes cause the progress output to render incorrectly, such as in the wrong color. But that's not an issue introduced by these changes.