### PR TITLE
Allow access to Loader's graph without creating a n2 db

### DIFF
--- a/src/load.rs
+++ b/src/load.rs
@@ -49,7 +49,7 @@ impl<'a> eval::Env for BuildImplicitVars<'a> {
 /// Internal state used while loading.
 #[derive(Default)]
 pub struct Loader {
-    graph: graph::Graph,
+    pub graph: graph::Graph,
     default: Vec<FileId>,
     /// rule name -> list of (key, val)
     rules: HashMap<String, SmallMap<String, eval::EvalString<String>>>,


### PR DESCRIPTION
Would you be amendable to this change?

I'm interesting in depending on n2's ninja parser & loader to access a `build.ninja`'s build graph but I don't want a n2 db created.