### PR TITLE
Move jemalloc to crate feature to make it optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ features = [
 ]
 
 [target.'cfg(not(any(windows, target_arch = "wasm32")))'.dependencies]
-jemallocator = "0.5.0"
+jemallocator = { version = "0.5", optional = true }
 
 [dev-dependencies]
 divan = "0.1.16"
@@ -51,4 +51,6 @@ name = "canon"
 harness = false
 
 [features]
+default = ["jemalloc"]
+jemalloc = ["jemallocator"]
 crlf = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,9 +24,11 @@ mod terminal;
 mod trace;
 mod work;
 
+#[cfg(feature = "jemalloc")]
 #[cfg(not(any(miri, windows, target_arch = "wasm32")))]
 use jemallocator::Jemalloc;
 
+#[cfg(feature = "jemalloc")]
 #[cfg(not(any(miri, windows, target_arch = "wasm32")))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;


### PR DESCRIPTION
I wanted to leverage the n2 parser in Rust without jemalloc set as the global allocator.